### PR TITLE
Set mem hook

### DIFF
--- a/config/github_actions.py
+++ b/config/github_actions.py
@@ -25,7 +25,7 @@ site_configuration = {
                             'options': ['--mem={size}'],
                         }
                     ],
-                    'max_jobs': 1
+                    'max_jobs': 1,
                     'extras': {
                         # Make sure to round down, otherwise a job might ask for more mem than is available
                         # per node

--- a/config/github_actions.py
+++ b/config/github_actions.py
@@ -26,6 +26,12 @@ site_configuration = {
                         }
                     ],
                     'max_jobs': 1
+                    'extras': {
+                        # Make sure to round down, otherwise a job might ask for more mem than is available
+                        # per node
+                        # This is a fictional amount, GH actions probably has less, but only does --dry-run
+                        'mem_per_node': 30  # in GiB
+                    },
                 }
             ]
         }

--- a/config/it4i_karolina.py
+++ b/config/it4i_karolina.py
@@ -53,6 +53,11 @@ site_configuration = {
                     'features': [
                         FEATURES[CPU],
                     ] + list(SCALES.keys()),
+                    'extras': {
+                        # Make sure to round down, otherwise a job might ask for more mem than is available
+                        # per node
+                        'mem_per_node': 219.345  # in GiB
+                    },
                     'descr': 'CPU Universal Compute Nodes, see https://docs.it4i.cz/karolina/hardware-overview/'
                 },
                 # We don't have GPU budget on Karolina at this time

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -66,7 +66,7 @@ site_configuration = {
                     },
                     'descr': 'CPU partition Standard, see https://en-doc.vega.izum.si/architecture/'
                 },
-{
+                # {
                 #     'name': 'gpu',
                 #     'scheduler': 'slurm',
                 #     'prepare_cmds': [

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -66,50 +66,50 @@ site_configuration = {
                     },
                     'descr': 'CPU partition Standard, see https://en-doc.vega.izum.si/architecture/'
                 },
-#                 {
-#                     'name': 'gpu',
-#                     'scheduler': 'slurm',
-#                     'prepare_cmds': [
-#                         'source %s' % common_eessi_init(),
-#                         # Pass job environment variables like $PATH, etc., into job steps
-#                         'export SLURM_EXPORT_ENV=ALL',
-#                         # Needed when using srun launcher
-#                         # 'export SLURM_MPI_TYPE=pmix',  # WARNING: this broke the GROMACS on Vega
-#                         # Avoid https://github.com/EESSI/software-layer/issues/136
-#                         # Can be taken out once we don't care about old OpenMPI versions anymore (pre-4.1.1)
-#                         'export OMPI_MCA_pml=ucx',
-#                     ],
-#                     'launcher': 'mpirun',
-#                     # Use --export=None to avoid that login environment is passed down to submitted jobs
-#                     'access': ['-p gpu', '--export=None'],
-#                     'environs': ['default'],
-#                     'max_jobs': 60,
-#                     'devices': [
-#                         {
-#                             'type': DEVICE_TYPES[GPU],
-#                             'num_devices': 4,
-#                         }
-#                     ],
-#                     'resources': [
-#                         {
-#                             'name': '_rfm_gpu',
-#                             'options': ['--gpus-per-node={num_gpus_per_node}'],
-#                         },
-#                         {
-#                             'name': 'memory',
-#                             'options': ['--mem={size}'],
-#                         }
-#                     ],
-#                     'features': [
-#                         FEATURES[GPU],
-#                     ] + list(SCALES.keys()),
-#                     'extras': {
-#                         # Make sure to round down, otherwise a job might ask for more mem than is available
-#                         # per node
-#                         'mem_per_node': 476.837  # in GiB (should be checked, its unclear from slurm.conf)
-#                     },
-#                     'descr': 'GPU partition, see https://en-doc.vega.izum.si/architecture/'
-#                 },
+{
+                #     'name': 'gpu',
+                #     'scheduler': 'slurm',
+                #     'prepare_cmds': [
+                #         'source %s' % common_eessi_init(),
+                #         # Pass job environment variables like $PATH, etc., into job steps
+                #         'export SLURM_EXPORT_ENV=ALL',
+                #         # Needed when using srun launcher
+                #         # 'export SLURM_MPI_TYPE=pmix',  # WARNING: this broke the GROMACS on Vega
+                #         # Avoid https://github.com/EESSI/software-layer/issues/136
+                #         # Can be taken out once we don't care about old OpenMPI versions anymore (pre-4.1.1)
+                #         'export OMPI_MCA_pml=ucx',
+                #     ],
+                #     'launcher': 'mpirun',
+                #     # Use --export=None to avoid that login environment is passed down to submitted jobs
+                #     'access': ['-p gpu', '--export=None'],
+                #     'environs': ['default'],
+                #     'max_jobs': 60,
+                #     'devices': [
+                #         {
+                #             'type': DEVICE_TYPES[GPU],
+                #             'num_devices': 4,
+                #         }
+                #     ],
+                #     'resources': [
+                #         {
+                #             'name': '_rfm_gpu',
+                #             'options': ['--gpus-per-node={num_gpus_per_node}'],
+                #         },
+                #         {
+                #             'name': 'memory',
+                #             'options': ['--mem={size}'],
+                #         }
+                #     ],
+                #     'features': [
+                #         FEATURES[GPU],
+                #     ] + list(SCALES.keys()),
+                #     'extras': {
+                #         # Make sure to round down, otherwise a job might ask for more mem than is available
+                #         # per node
+                #         'mem_per_node': 476.837  # in GiB (should be checked, its unclear from slurm.conf)
+                #     },
+                #     'descr': 'GPU partition, see https://en-doc.vega.izum.si/architecture/'
+                # },
             ]
         },
     ],

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -66,45 +66,50 @@ site_configuration = {
                     },
                     'descr': 'CPU partition Standard, see https://en-doc.vega.izum.si/architecture/'
                 },
-                {
-                    'name': 'gpu',
-                    'scheduler': 'slurm',
-                    'prepare_cmds': [
-                        'source %s' % common_eessi_init(),
-                        # Pass job environment variables like $PATH, etc., into job steps
-                        'export SLURM_EXPORT_ENV=ALL',
-                        # Needed when using srun launcher
-                        # 'export SLURM_MPI_TYPE=pmix',  # WARNING: this broke the GROMACS on Vega
-                        # Avoid https://github.com/EESSI/software-layer/issues/136
-                        # Can be taken out once we don't care about old OpenMPI versions anymore (pre-4.1.1)
-                        'export OMPI_MCA_pml=ucx',
-                    ],
-                    'launcher': 'mpirun',
-                    # Use --export=None to avoid that login environment is passed down to submitted jobs
-                    'access': ['-p gpu', '--export=None'],
-                    'environs': ['default'],
-                    'max_jobs': 60,
-                    'devices': [
-                        {
-                            'type': DEVICE_TYPES[GPU],
-                            'num_devices': 4,
-                        }
-                    ],
-                    'resources': [
-                        {
-                            'name': '_rfm_gpu',
-                            'options': ['--gpus-per-node={num_gpus_per_node}'],
-                        },
-                        {
-                            'name': 'memory',
-                            'options': ['--mem={size}'],
-                        }
-                    ],
-                    'features': [
-                        FEATURES[GPU],
-                    ] + list(SCALES.keys()),
-                    'descr': 'GPU partition, see https://en-doc.vega.izum.si/architecture/'
-                },
+#                 {
+#                     'name': 'gpu',
+#                     'scheduler': 'slurm',
+#                     'prepare_cmds': [
+#                         'source %s' % common_eessi_init(),
+#                         # Pass job environment variables like $PATH, etc., into job steps
+#                         'export SLURM_EXPORT_ENV=ALL',
+#                         # Needed when using srun launcher
+#                         # 'export SLURM_MPI_TYPE=pmix',  # WARNING: this broke the GROMACS on Vega
+#                         # Avoid https://github.com/EESSI/software-layer/issues/136
+#                         # Can be taken out once we don't care about old OpenMPI versions anymore (pre-4.1.1)
+#                         'export OMPI_MCA_pml=ucx',
+#                     ],
+#                     'launcher': 'mpirun',
+#                     # Use --export=None to avoid that login environment is passed down to submitted jobs
+#                     'access': ['-p gpu', '--export=None'],
+#                     'environs': ['default'],
+#                     'max_jobs': 60,
+#                     'devices': [
+#                         {
+#                             'type': DEVICE_TYPES[GPU],
+#                             'num_devices': 4,
+#                         }
+#                     ],
+#                     'resources': [
+#                         {
+#                             'name': '_rfm_gpu',
+#                             'options': ['--gpus-per-node={num_gpus_per_node}'],
+#                         },
+#                         {
+#                             'name': 'memory',
+#                             'options': ['--mem={size}'],
+#                         }
+#                     ],
+#                     'features': [
+#                         FEATURES[GPU],
+#                     ] + list(SCALES.keys()),
+#                     'extras': {
+#                         # Make sure to round down, otherwise a job might ask for more mem than is available
+#                         # per node
+#                         'mem_per_node': 476.837  # in GiB (should be checked, its unclear from slurm.conf)
+#                     },
+#                     'descr': 'GPU partition, see https://en-doc.vega.izum.si/architecture/'
+#                 },
             ]
         },
     ],

--- a/config/izum_vega.py
+++ b/config/izum_vega.py
@@ -59,6 +59,11 @@ site_configuration = {
                     'features': [
                         FEATURES[CPU],
                     ] + list(SCALES.keys()),
+                    'extras': {
+                        # Make sure to round down, otherwise a job might ask for more mem than is available
+                        # per node
+                        'mem_per_node': 238.418  # in GiB
+                    },
                     'descr': 'CPU partition Standard, see https://en-doc.vega.izum.si/architecture/'
                 },
                 {

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -53,6 +53,11 @@ site_configuration = {
                     'features': [
                         FEATURES[CPU],
                     ] + list(SCALES.keys()),
+                    'extras': {
+                        # Make sure to round down, otherwise a job might ask for more mem than is available
+                        # per node
+                        'mem_per_node': 213.623  # in GiB
+                    },
                     'descr': 'AMD Rome CPU partition with native EESSI stack'
                 },
                 {
@@ -73,7 +78,9 @@ site_configuration = {
                         FEATURES[CPU],
                     ] + list(SCALES.keys()),
                     'extras': {
-                        'mem_per_node': 336
+                        # Make sure to round down, otherwise a job might ask for more mem than is available
+                        # per node
+                        'mem_per_node': 320.434  # in GiB
                     },
                     'descr': 'AMD Genoa CPU partition with native EESSI stack'
                 },
@@ -108,6 +115,9 @@ site_configuration = {
                     ] + valid_scales_snellius_gpu,
                     'extras': {
                         GPU_VENDOR: GPU_VENDORS[NVIDIA],
+                        # Make sure to round down, otherwise a job might ask for more mem than is available
+                        # per node
+                        'mem_per_node': 457.763  # in GiB
                     },
                     'descr': 'Nvidia A100 GPU partition with native EESSI stack'
                 },

--- a/config/surf_snellius.py
+++ b/config/surf_snellius.py
@@ -72,6 +72,9 @@ site_configuration = {
                     'features': [
                         FEATURES[CPU],
                     ] + list(SCALES.keys()),
+                    'extras': {
+                        'mem_per_node': 336
+                    },
                     'descr': 'AMD Genoa CPU partition with native EESSI stack'
                 },
 

--- a/eessi/testsuite/hooks.py
+++ b/eessi/testsuite/hooks.py
@@ -373,11 +373,6 @@ def filter_valid_systems_by_device_type(test: rfm.RegressionTest, required_devic
     log(f'valid_systems set to {test.valid_systems}')
 
 
-## TODO: function should take everything in MB, as schedulers (at least slurm) does not except asking for fractional memory
-## ie --mem=7.0G is invalid. This should be done as --mem=7168M.
-## It's probably better if this function does everything in MB, and the ReFrame config also specifies available mem per node in MB.
-## Then, we should make sure the numbers are integers by rounding up for app_mem_req (1 MB more should never really be an issue)
-## and probably down for the proportional_mem (as to not ask for more than the equivalent share of a core)
 def req_memory_per_node(test: rfm.RegressionTest, app_mem_req):
     """
     This hook will request a specific amount of memory per node to the batch scheduler.
@@ -434,7 +429,7 @@ def req_memory_per_node(test: rfm.RegressionTest, app_mem_req):
         # Request the maximum of the proportional_mem, and app_mem_req to the scheduler
         req_mem_per_node = max(proportional_mem, app_mem_req)
 
-        test.extra_resources = {'memory': {'size': f'{req_mem_per_node}M' }}
+        test.extra_resources = {'memory': {'size': f'{req_mem_per_node}M'}}
         log(f"Requested {req_mem_per_node} MB per node from the SLURM batch scheduler")
 
     elif scheduler_name == 'torque':
@@ -462,6 +457,7 @@ def req_memory_per_node(test: rfm.RegressionTest, app_mem_req):
         msg += " Please expand the functionality of hooks.req_memory_per_node for your scheduler."
         # Warnings will, at default loglevel, be printed on stdout when executing the ReFrame command
         logger.warning(msg)
+
 
 def set_modules(test: rfm.RegressionTest):
     """

--- a/eessi/testsuite/tests/apps/QuantumESPRESSO.py
+++ b/eessi/testsuite/tests/apps/QuantumESPRESSO.py
@@ -99,7 +99,7 @@ class EESSI_QuantumESPRESSO_PW(QEspressoPWCheck):
 
     @run_after('setup')
     def request_mem(self):
-        memory_required = self.num_tasks_per_node * 1 + 2
+        memory_required = self.num_tasks_per_node * 0.9 + 4
         hooks.req_memory_per_node(test=self, app_mem_req=memory_required)
 
     @run_after('setup')

--- a/eessi/testsuite/tests/apps/QuantumESPRESSO.py
+++ b/eessi/testsuite/tests/apps/QuantumESPRESSO.py
@@ -98,6 +98,11 @@ class EESSI_QuantumESPRESSO_PW(QEspressoPWCheck):
             hooks.assign_tasks_per_compute_unit(test=self, compute_unit=COMPUTE_UNIT[CPU])
 
     @run_after('setup')
+    def request_mem(self):
+        memory_required = self.num_tasks_per_node * 1 + 2
+        hooks.req_memory_per_node(test=self, app_mem_req=memory_required)
+
+    @run_after('setup')
     def set_omp_num_threads(self):
         """
         Set number of OpenMP threads via OMP_NUM_THREADS.

--- a/eessi/testsuite/utils.py
+++ b/eessi/testsuite/utils.py
@@ -145,7 +145,41 @@ def check_proc_attribute_defined(test: rfm.RegressionTest, attribute) -> bool:
     else:
         msg = (
             "This test's current_partition is not set yet. "
-            "The function utils.proc_attribute_defined should only be called after the setup() phase of ReFrame."
+            "The function utils.check_proc_attribute_defined should only be called after the setup() phase of ReFrame."
             "This is a programming error, please report this issue."
         )
-        raise AttributeError(msg)
+    raise AttributeError(msg)
+
+
+def check_extras_key_defined(test: rfm.RegressionTest, extra_key) -> bool:
+    """
+    Checks if a specific key is defined in the 'extras' dictionary for the current partition
+    (i.e. if test.current_partition.extras[extra_key] is defined)
+    If not, throws an informative error message.
+    Note that partition extras are defined by free text keys, so any string is (potentially) valid.
+
+    Arguments:
+    - test: the reframe regression test instance for which should be checked if the key is defined in 'extras'
+    - extra_key: key for which to check in the 'extras' dictionary
+
+    Return:
+    - True (bool) if the key is defined
+    - Function does not return (but raises an error) if the attribute is undefined
+    """
+
+    if test.current_partition:
+        if extra_key in test.current_partition.extras:
+            return True
+        else:
+            msg = (
+                f"Key '{extra_key}' missing in the 'extras' dictionary for partition '{test.current_partition.name}'."
+                "Please define this key for the relevant partition in the ReFrame configuration file (see "
+                "https://reframe-hpc.readthedocs.io/en/stable/config_reference.html#config.systems.partitions.extras)."
+            )
+    else:
+        msg = (
+            "This test's current_partition is not set yet. "
+            "The function utils.check_extras_key_defined should only be called after the setup() phase of ReFrame."
+            "This is a programming error, please report this issue."
+        )
+    raise AttributeError(msg)


### PR DESCRIPTION
I _think_ this should do it. The function requesting a certain amount of memory for the QE test is fictional - I haven't checked the memory footprint for the QE tests for all sizes. That's an exercise I leave for you as developer of the test to fill in :D It _does_ seem to at least be sufficient: all the tests pass on the system where they were failing before, even for the 1/2/4 core count cases.

Probably, we should at least have different functions for the different use cases. The smallest use case can probably run with a lot less memory as well :) A linear function is probably also a bad approximation, but since the memory requirements are not excessive (most HPC nodes have at least 1 GB per core), 'worst case' it now asks for a bit too much...